### PR TITLE
Test option now also accepts an array of regular expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 node_modules
 npm-debug.log*
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Via `.babelrc` or `babel-loader`.
   "plugins": [
     [
       "babel-plugin-transform-remove-imports", {
-        "test": "(less|css)$"
+        "test": "\\.(less|css)$"
       }
     ]
   ]
@@ -47,12 +47,19 @@ import { Button } from 'uiw';
 import { Select } from '@uiw/core';
 ```
 
-## Optiosn
+## Options
 
-- `test: string` Matches based on regular expressions.
-- `removeAll: boolean` Delete all import packages.
+- `test: RegExp | string | (RegExp | string)[]`
+  
+  A regular expression to match the imports that will be removed.
+  It could be a string or a RegExp object.
+  You could also pass an array here.
 
-## Programatic Usage
+- `removeAll: boolean`
+
+  Deletes all imports.
+
+## Programmatic Usage
 
 ```js
 import plugin from 'babel-plugin-transform-remove-imports'
@@ -62,7 +69,7 @@ function replace (code) {
   return transform(code, {
     babelrc: false,
     plugins: [
-      [plugin, { test: "(less|css)$" }]
+      [plugin, { test: /\.(less|css)$/ }]
     ],
   }).code;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,50 @@ export default function () {
     visitor: {
       // https://babeljs.io/docs/en/babel-types#importdeclaration
       ImportDeclaration(path, state) {
-        if (state.opts.removeAll) {
+
+        const { node } = path;
+        const { source } = node;
+        const { opts } = state;
+
+        if (opts.removeAll) {
           path.remove();
           return;
         }
-        if (!state.opts.test) return;
-        if (!path.node.source || !path.node.source.value) return;
-        if ((new RegExp(state.opts.test)).test(path.node.source.value)) {
+
+        if (!opts.test) {
+          console.warn("transform-remove-imports: \"test\" option should be specified");
+          return;
+        }
+
+        /** @var {string} importName */
+        const importName = (source && source.value ? source.value : undefined);
+        if (importName && testMatches(importName, opts.test)) {
           path.remove();
         }
+
       },
     }
   };
+}
+
+
+/**
+ * Determines if the import matches the specified tests.
+ *
+ * @param {string} importName
+ * @param {RegExp|RegExp[]|string|string[]} test
+ */
+function testMatches(importName, test) {
+
+  // Normalizing tests
+  const tests = Array.isArray(test) ? test : [test];
+
+  // Finding out if at least one test matches
+  return tests.some(regex => {
+    if (typeof regex === "string") {
+      regex = new RegExp(regex);
+    }
+    return regex.test(importName);
+  });
+
 }

--- a/test/fixtures/test-array/input.js
+++ b/test/fixtures/test-array/input.js
@@ -1,0 +1,8 @@
+
+import { import1 } from '@acme';
+import { import2 } from '@acme/sub-path';
+
+import { Foo } from 'foo';
+import { Bar } from 'bar';
+import { Baz } from 'baz';
+import { Bazinga } from 'baz/bazinga';

--- a/test/fixtures/test-array/output.js
+++ b/test/fixtures/test-array/output.js
@@ -1,0 +1,3 @@
+import { import1 } from '@acme';
+import { import2 } from '@acme/sub-path';
+import { Baz } from 'baz';

--- a/test/fixtures/test-regexp-object/input.js
+++ b/test/fixtures/test-regexp-object/input.js
@@ -1,0 +1,6 @@
+
+import { Foo } from '@acme';
+import { Bar } from '@acme/bar';
+import { Bazinga } from 'bazinga';
+
+import { Qux } from 'baz/qux';

--- a/test/fixtures/test-regexp-object/output.js
+++ b/test/fixtures/test-regexp-object/output.js
@@ -1,0 +1,3 @@
+import { Foo } from '@acme';
+import { Bar } from '@acme/bar';
+import { Bazinga } from 'bazinga';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ import plugin from '../src/index';
 
 const pluginBaseOpts = {
   "presets": [],
-}
+};
 
 const fixtureDir = join(__dirname, 'fixtures');
 const fixtures = readdirSync(fixtureDir);
@@ -25,12 +25,21 @@ fixtures.map((caseName) => {
       pluginBaseOpts.plugins = [
         [plugin, { removeAll: true }]
       ]
+    } else if (caseName === 'test-regexp-object') {
+      pluginBaseOpts.presets = [["@babel/preset-env", { "modules": false }]];
+      pluginBaseOpts.plugins = [
+        [plugin, { test: /^baz($|\/)/ }]
+      ]
+    } else if (caseName === 'test-array') {
+      pluginBaseOpts.presets = [["@babel/preset-env", { "modules": false }]];
+      pluginBaseOpts.plugins = [
+        [plugin, { test: [/^foo$/, /^bar$/, /^baz\//] }]
+      ]
     } else {
       pluginBaseOpts.presets = [["@babel/preset-env", { "modules": false }]];
     }
-
     const code = transformSync(readFileSync(inputFile), pluginBaseOpts).code;
     const expected = readFileSync(outputFile).toString();
     expect(code).toBe(expected);
   });
-})
+});


### PR DESCRIPTION
In complex projects you would want to pass an array of regular expressions instead of a single expression as a `test` option.

This PR implements this behavior. I've also added new tests to cover new functionality as well as updated the README.

This should be a minor update (i.e. `1.3.0`).